### PR TITLE
Fix for wrong support value

### DIFF
--- a/src/database/DatabaseAdmin.java
+++ b/src/database/DatabaseAdmin.java
@@ -658,9 +658,9 @@ public class DatabaseAdmin {
                   }
                   
               }
-
+              
               iIndiceLigne++;
-              if (iIndiceLigne == m_iNombreLignes - 1) break;
+              if (iIndiceLigne == m_iNombreLignes) break;
               tValeursChamps = csvParser.m_data[iIndiceLigne];
           }
 


### PR DESCRIPTION
The last line of the CSV file was not being read, this was causing the
value for each item in the last row of the database to have the same
value, hence increasing the support by 1. Fixes #2.
